### PR TITLE
Add clone json endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -551,7 +551,7 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     raindrops (0.13.0)
-    rake (12.0.0)
+    rake (10.5.0)
     ransack (0.7.2)
       actionpack (~> 3.0)
       activerecord (~> 3.0)

--- a/app/assets/javascripts/admin/services/bulk_products.js.coffee
+++ b/app/assets/javascripts/admin/services/bulk_products.js.coffee
@@ -1,4 +1,4 @@
-angular.module("ofn.admin").factory "BulkProducts", (PagedFetcher, dataFetcher) ->
+angular.module("ofn.admin").factory "BulkProducts", (PagedFetcher, dataFetcher, $http) ->
   new class BulkProducts
     products: []
 
@@ -11,14 +11,8 @@ angular.module("ofn.admin").factory "BulkProducts", (PagedFetcher, dataFetcher) 
       PagedFetcher.fetch url, (data) => @addProducts data.products
 
     cloneProduct: (product) ->
-      dataFetcher("/admin/products/" + product.permalink_live + "/clone.json").then (data) =>
-        # Ideally we would use Spree's built in respond_override helper here to redirect the
-        # user after a successful clone with .json in the accept headers
-        # However, at the time of writing there appears to be an issue which causes the
-        # respond_with block in the destroy action of Spree::Admin::Product to break
-        # when a respond_overrride for the clone action is used.
-        id = data.product.id
-        dataFetcher("/api/products/" + id + "?template=bulk_show").then (newProduct) =>
+      $http.post("/api/products/" + product.id + "/clone").success (data) =>
+        dataFetcher("/api/products/" + data.id + "?template=bulk_show").then (newProduct) =>
           @unpackProduct newProduct
           @insertProductAfter(product, newProduct)
 

--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -8,9 +8,6 @@ Spree::Admin::ProductsController.class_eval do
   before_filter :load_spree_api_key, :only => [:bulk_edit, :variant_overrides]
   before_filter :strip_new_properties, only: [:create, :update]
 
-
-  respond_to :json, :only => :clone
-
   respond_override create: { html: {
     success: lambda {
       if params[:button] == "add_another"
@@ -22,7 +19,6 @@ Spree::Admin::ProductsController.class_eval do
     failure: lambda {
       render :new
     } } }
-  #respond_override :clone => { :json => {:success => lambda { redirect_to bulk_index_admin_products_url+"?q[id_eq]=#{@new.id}" } } }
 
   def product_distributions
   end

--- a/app/controllers/spree/api/products_controller_decorator.rb
+++ b/app/controllers/spree/api/products_controller_decorator.rb
@@ -37,6 +37,17 @@ Spree::Api::ProductsController.class_eval do
     respond_with(@product, :status => 204)
   end
 
+  # POST /api/products/:product_id/clone
+  #
+  def clone
+    authorize! :create, Spree::Product
+    original_product = find_product(params[:product_id])
+    authorize! :update, original_product
+
+    @product = original_product.duplicate
+
+    respond_with(@product, status: 201, default_template: :show)
+  end
 
   private
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,6 +228,7 @@ Spree::Core::Engine.routes.prepend do
         get :overridable
       end
       delete :soft_delete
+      post :clone
 
       resources :variants do
         delete :soft_delete

--- a/spec/controllers/spree/api/products_controller_spec.rb
+++ b/spec/controllers/spree/api/products_controller_spec.rb
@@ -107,5 +107,43 @@ module Spree
         product1.deleted_at.should_not be_nil
       end
     end
+
+    describe '#clone' do
+      before do
+        spree_post :clone, product_id: product1.id, format: :json
+      end
+
+      context 'as a normal user' do
+        sign_in_as_user!
+
+        it 'denies access' do
+          assert_unauthorized!
+        end
+      end
+
+      context 'as an enterprise user' do
+        sign_in_as_enterprise_user! [:supplier]
+
+        it 'responds with a successful response' do
+          expect(response.status).to eq(201)
+        end
+
+        it 'clones the product' do
+          expect(json_response['name']).to eq("COPY OF #{product1.name}")
+        end
+      end
+
+      context 'as an administrator' do
+        sign_in_as_admin!
+
+        it 'responds with a successful response' do
+          expect(response.status).to eq(201)
+        end
+
+        it 'clones the product' do
+          expect(json_response['name']).to eq("COPY OF #{product1.name}")
+        end
+      end
+    end
   end
 end

--- a/spec/javascripts/unit/admin/services/bulk_products_spec.js.coffee
+++ b/spec/javascripts/unit/admin/services/bulk_products_spec.js.coffee
@@ -38,18 +38,14 @@ describe "BulkProducts service", ->
 
 
   describe "cloning products", ->
-    it "clones products using a http get request to /admin/products/(permalink)/clone.json", ->
+    it "clones products using a http post request to /api/products/(id)/clone", ->
       BulkProducts.products = [
         id: 13
-        permalink_live: "oranges"
       ]
-      $httpBackend.expectGET("/admin/products/oranges/clone.json").respond 200,
-        product:
-          id: 17
-          name: "new_product"
+      $httpBackend.expectPOST("/api/products/13/clone").respond 201,
+        id: 17
       $httpBackend.expectGET("/api/products/17?template=bulk_show").respond 200, [
         id: 17
-        name: "new_product"
       ]
       BulkProducts.cloneProduct BulkProducts.products[0]
       $httpBackend.flush()
@@ -57,15 +53,13 @@ describe "BulkProducts service", ->
     it "adds the product", ->
       originalProduct =
         id: 16
-        permalink_live: "oranges"
       clonedProduct =
         id: 17
 
       spyOn(BulkProducts, "insertProductAfter")
       spyOn(BulkProducts, "unpackProduct")
       BulkProducts.products = [originalProduct]
-      $httpBackend.expectGET("/admin/products/oranges/clone.json").respond 200,
-        product: clonedProduct
+      $httpBackend.expectPOST("/api/products/16/clone").respond 201, clonedProduct
       $httpBackend.expectGET("/api/products/17?template=bulk_show").respond 200, clonedProduct
       BulkProducts.cloneProduct BulkProducts.products[0]
       $httpBackend.flush()


### PR DESCRIPTION
### The problem
There is a [feature spec](https://github.com/openfoodfoundation/openfoodnetwork/blob/master/spec/features/admin/bulk_product_update_spec.rb#L413) failing because the current view is using an endpoint which response has changed in more recent Spree.

```
     Failure/Error: expect(page.find("#status-message")).to have_content "Changes saved."
     Capybara::Poltergeist::JavascriptError:
       One or more errors were raised in the Javascript code on the page. If you don't care about these errors, you can ignore them by setting js_errors: false in your Poltergeist configuration (see documentation for details).
       
       Error: undefined is not an object (evaluating 'data.product.id')
```

The problem is that the `GET /admin/products/:product_permalink/clone.json` endpoint changed its internals and cannot be overridden. Basically before it was using `#respond_with()` but now it's using `#redirect_to()`.

**Spree::Admin::ProductsController#clone** [right now](https://github.com/openfoodfoundation/spree/blob/spree-upgrade-step1c/core/app/controllers/spree/admin/products_controller.rb#L55) vs [in the Spree upgrade branch](https://github.com/openfoodfoundation/spree/blob/spree-upgrade-step-3/backend/app/controllers/spree/admin/products_controller.rb#L57)

This change makes all the responses to be HTML and it breaks the `data.product.id` in the view since it was expecting a JS object instead.

### A possible solution
Our proposal is to add a new JSON endpoint to the API:
```
GET /api/products/:product_id/clone
```
In this way we call a pure JSON endpoint from a AJAX call instead of reusing an HTML one.

### Problems
In our opinion this endpoint should be use a `POST` verb since it's modifying the internal state. `GET` requests should always be idempotent.

The problem is that I couldn't find any JS helper to make the AJAX call. The `dataFetch()` helper only manages (correctly) `GET` requests. Do we have already a helper for `POST` requests somewhere? We justs didn't want to throw a `$.ajax()` in there 😬 