### PR TITLE
Fix/reproduce line item issue

### DIFF
--- a/lib/open_food_network/distribution_change_validator.rb
+++ b/lib/open_food_network/distribution_change_validator.rb
@@ -1,7 +1,7 @@
 class DistributionChangeValidator
 
   def initialize(order)
-    @order = order.reload
+    @order = order
   end
 
   def can_change_to_distributor?(distributor)

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -36,6 +36,9 @@ describe LineItemsController do
       item
     end
 
+    let(:order) { item.order }
+    let(:order_cycle) { create(:simple_order_cycle, distributors: [distributor], variants: [order.line_item_variants]) }
+
     before { controller.stub spree_current_user: item.order.user }
 
     context "without a line item id" do
@@ -56,42 +59,32 @@ describe LineItemsController do
       end
 
       context "where the item's order is associated with the current user" do
-        before { item.order.update_attributes(user_id: user.id) }
+        before { order.update_attributes!(user_id: user.id) }
 
-        context "without an order cycle" do
+        context "without an order cycle or distributor" do
           it "denies deletion" do
             delete :destroy, params
             expect(response.status).to eq 403
           end
         end
 
-        context "with an order cycle" do
-          before { item.order.update_attributes(order_cycle_id: order_cycle.id) }
+        context "with an order cycle and distributor" do
+          before { order.update_attributes!(order_cycle_id: order_cycle.id, distributor_id: distributor.id) }
 
-          context "without a distributor" do
+          context "where changes are not allowed" do
             it "denies deletion" do
               delete :destroy, params
               expect(response.status).to eq 403
             end
           end
 
-          context "where the item's order has a distributor" do
-            before { item.order.update_attributes(distributor_id: distributor.id) }
-            context "where changes are not allowed" do
-              it "denies deletion" do
-                delete :destroy, params
-                expect(response.status).to eq 403
-              end
-            end
+          context "where changes are allowed" do
+            before { distributor.update_attributes!(allow_order_changes: true) }
 
-            context "where changes are allowed" do
-              before { distributor.update_attributes(allow_order_changes: true) }
-
-              it "deletes the line item" do
-                delete :destroy, params
-                expect(response.status).to eq 204
-                expect { item.reload }.to raise_error ActiveRecord::RecordNotFound
-              end
+            it "deletes the line item" do
+              delete :destroy, params
+              expect(response.status).to eq 204
+              expect { item.reload }.to raise_error ActiveRecord::RecordNotFound
             end
           end
         end

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -32,6 +32,7 @@ describe LineItemsController do
       order = create(:completed_order_with_totals)
       item = create(:line_item, order: order)
       while !order.completed? do break unless order.next! end
+      order.reload
       item
     end
 


### PR DESCRIPTION
- Made the variant available through the order cycle.
- Added bangs to the `update_attributes` calls. Should have done this from the beginning.

This should fix the issue validation failure.