### PR TITLE
Add missing translation

### DIFF
--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -79,7 +79,7 @@ Spree::Admin::OrdersController.class_eval do
     template = if Spree::Config.invoice_style2? then "spree/admin/orders/invoice2" else "spree/admin/orders/invoice" end
     pdf = render_to_string pdf: "invoice-#{@order.number}.pdf", template: template, formats: [:html], encoding: "UTF-8"
     Spree::OrderMailer.invoice_email(@order.id, pdf).deliver
-    flash[:success] = t(:invoice_email_sent)
+    flash[:success] = t('admin.orders.invoice_email_sent')
 
     respond_with(@order) { |format| format.html { redirect_to edit_admin_order_path(@order) } }
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,6 +323,7 @@ en:
         new_powertip: These products are available to be added to your inventory. Click 'Add' to add a product to your inventory, or 'Hide' to hide it from view. You can always change your mind later!
 
     orders:
+      invoice_email_sent: 'Invoice sent'
       bulk_management:
         tip: "Use this page to alter product quantities across multiple orders. Products may also be removed from orders entirely, if required."
         shared: "Shared Resource?"


### PR DESCRIPTION
When sending the invoice from the `/admin/order` page the resulting flash message at the top of the page warns about a missing copy. 

![send_invoice](https://user-images.githubusercontent.com/762088/28130086-0a965c68-6736-11e7-882b-35d3591a34d7.png)

And with this PR:

![flash](https://user-images.githubusercontent.com/762088/28130096-106c4ba2-6736-11e7-9a65-01d2ee7fb70b.png)
