### PR TITLE
Fix deleting line item #step6

### DIFF
--- a/app/controllers/spree/admin/line_items_controller_decorator.rb
+++ b/app/controllers/spree/admin/line_items_controller_decorator.rb
@@ -35,11 +35,11 @@ Spree::Admin::LineItemsController.class_eval do
   def update
     respond_to do |format|
       format.html { render_order_form }
-      format.json {
+      format.js {
         if @line_item.update_attributes(params[:line_item])
           render nothing: true, status: 204 # No Content, does not trigger ng resource auto-update
         else
-          render json: {errors: @line_item.errors}, status: 412
+          render json: { errors: @line_item.errors }, status: 412
         end
       }
     end

--- a/app/controllers/spree/admin/line_items_controller_decorator.rb
+++ b/app/controllers/spree/admin/line_items_controller_decorator.rb
@@ -2,8 +2,6 @@ Spree::Admin::LineItemsController.class_eval do
   prepend_before_filter :load_order, except: :index
   around_filter :apply_enterprise_fees_with_lock, only: :update
 
-  respond_to :json
-
   # TODO make updating line items faster by creating a bulk update method
 
   def index
@@ -52,7 +50,7 @@ Spree::Admin::LineItemsController.class_eval do
 
     respond_to do |format|
       format.html { render_order_form }
-      format.json { render nothing: true, status: 204 } # No Content
+      format.js { render nothing: true, status: 204 } # No Content
     end
   end
 

--- a/app/controllers/spree/admin/line_items_controller_decorator.rb
+++ b/app/controllers/spree/admin/line_items_controller_decorator.rb
@@ -32,6 +32,10 @@ Spree::Admin::LineItemsController.class_eval do
     end
   end
 
+  # TODO: simplify this, 3 formats per action is too much
+  #       we need `js` format for admin/orders/edit (jquery-rails gem)
+  #       we need `json` format for admin/orders/bulk_management (angular)
+  #       we don't know if `html` format is needed
   def update
     respond_to do |format|
       format.html { render_order_form }
@@ -42,15 +46,27 @@ Spree::Admin::LineItemsController.class_eval do
           render json: { errors: @line_item.errors }, status: 412
         end
       }
+      format.json {
+        if @line_item.update_attributes(params[:line_item])
+          render nothing: true, status: 204 # No Content, does not trigger ng resource auto-update
+        else
+          render json: { errors: @line_item.errors }, status: 412
+        end
+      }
     end
   end
 
+  # TODO: simplify this, 3 formats per action is too much:
+  #       we need `js` format for admin/orders/edit (jquery-rails gem)
+  #       we need `json` format for admin/orders/bulk_management (angular)
+  #       we don't know if `html` format is needed
   def destroy
     @line_item.destroy
 
     respond_to do |format|
       format.html { render_order_form }
       format.js { render nothing: true, status: 204 } # No Content
+      format.json { render nothing: true, status: 204 } # No Content
     end
   end
 

--- a/spec/controllers/spree/admin/line_items_controller_spec.rb
+++ b/spec/controllers/spree/admin/line_items_controller_spec.rb
@@ -143,14 +143,15 @@ describe Spree::Admin::LineItemsController do
     end
   end
 
-  describe "#update" do
+  describe '#update' do
     let(:supplier) { create(:supplier_enterprise) }
     let(:distributor1) { create(:distributor_enterprise) }
     let(:coordinator) { create(:distributor_enterprise) }
     let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator) }
     let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
     let!(:line_item1) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
-    let(:params) { { format: :json, id: line_item1.id, order_id: order1.number, line_item: { quantity: 3, final_weight_volume: 3000, price: 3.00 } } }
+    let(:line_item_params) { { quantity: 3, final_weight_volume: 3000, price: 3.00 } }
+    let(:params) { { id: line_item1.id, order_id: order1.number, line_item: line_item_params } }
 
     context "as an enterprise user" do
       context "producer enterprise" do
@@ -172,7 +173,7 @@ describe Spree::Admin::LineItemsController do
         end
 
         it "updates the line item" do
-          spree_put :update, params
+          xhr :put, :update, params
           line_item1.reload
           expect(line_item1.quantity).to eq 3
           expect(line_item1.final_weight_volume).to eq 3000
@@ -180,20 +181,44 @@ describe Spree::Admin::LineItemsController do
         end
 
         it "returns an empty JSON response" do
-          spree_put :update, params.merge(format: :json)
+          xhr :put, :update, params
           expect(response.body).to eq ' '
         end
 
-        it "returns an HTML response with the order form" do
-          spree_put :update, params.merge(format: :html)
-          expect(response.body).to match /admin_order_form_fields/
+        it 'returns a 204 response' do
+          xhr :put, :update, params
+          expect(response.status).to eq 204
+        end
+
+        context 'when the line item params are not correct' do
+          let(:line_item_params) { { price: 'hola' } }
+          let(:errors) { { 'price' => ['is not a number'] } }
+
+          it 'returns a JSON with the errors' do
+            xhr :put, :update, params
+            expect(JSON.parse(response.body)['errors']).to eq(errors)
+          end
+
+          it 'returns a 412 response' do
+            xhr :put, :update, params
+            expect(response.status).to eq 412
+          end
+        end
+
+        context 'when the request is HTML' do
+          before { params.merge(format: :html) }
+
+          it 'returns an HTML response with the order form' do
+            spree_put :update, params
+            expect(response.body).to match /admin_order_form_fields/
+          end
         end
       end
 
       context "hub enterprise" do
         before do
           controller.stub spree_current_user: distributor1.owner
-          spree_put :update, params
+          xhr :put, :update, params
         end
 
         it "updates the line item" do
@@ -206,7 +231,7 @@ describe Spree::Admin::LineItemsController do
     end
   end
 
-  describe "#destroy" do
+  describe '#destroy' do
     render_views
 
     let(:supplier) { create(:supplier_enterprise) }
@@ -215,26 +240,35 @@ describe Spree::Admin::LineItemsController do
     let(:order_cycle) { create(:simple_order_cycle, coordinator: coordinator) }
     let!(:order1) { FactoryGirl.create(:order, order_cycle: order_cycle, state: 'complete', completed_at: Time.zone.now, distributor: distributor1, billing_address: FactoryGirl.create(:address) ) }
     let!(:line_item1) { FactoryGirl.create(:line_item, order: order1, product: FactoryGirl.create(:product, supplier: supplier)) }
-    let(:params) { { format: :json, id: line_item1.id, order_id: order1.number } }
+    let(:params) { { id: line_item1.id, order_id: order1.number } }
 
     before do
       controller.stub spree_current_user: coordinator.owner
     end
 
-    it "destroys the line item" do
+    it 'destroys the line item' do
       expect {
-        spree_delete :destroy, params
+        xhr :delete, :destroy, params
       }.to change { Spree::LineItem.where(id: line_item1).count }.from(1).to(0)
     end
 
-    it "returns an empty JSON response" do
-      spree_delete :destroy, params.merge(format: :json)
+    it 'returns an empty JSON response' do
+      xhr :delete, :destroy, params
       expect(response.body).to eq ' '
     end
 
-    it "returns an HTML response with the order form" do
-      spree_delete :destroy, params.merge(format: :html)
-      expect(response.body).to match /admin_order_form_fields/
+    it 'returns a 204 response' do
+      xhr :delete, :destroy, params
+      expect(response.status).to eq 204
+    end
+
+    context 'when the request is HTML' do
+      before { params.merge(format: :html) }
+
+      it 'returns an HTML response with the order form' do
+        spree_delete :destroy, params
+        expect(response.body).to match /admin_order_form_fields/
+      end
     end
   end
 end

--- a/spec/controllers/spree/admin/line_items_controller_spec.rb
+++ b/spec/controllers/spree/admin/line_items_controller_spec.rb
@@ -172,41 +172,82 @@ describe Spree::Admin::LineItemsController do
           controller.stub spree_current_user: coordinator.owner
         end
 
-        it "updates the line item" do
-          xhr :put, :update, params
-          line_item1.reload
-          expect(line_item1.quantity).to eq 3
-          expect(line_item1.final_weight_volume).to eq 3000
-          expect(line_item1.price).to eq 3.00
-        end
-
-        it "returns an empty JSON response" do
-          xhr :put, :update, params
-          expect(response.body).to eq ' '
-        end
-
-        it 'returns a 204 response' do
-          xhr :put, :update, params
-          expect(response.status).to eq 204
-        end
-
-        context 'when the line item params are not correct' do
-          let(:line_item_params) { { price: 'hola' } }
-          let(:errors) { { 'price' => ['is not a number'] } }
-
-          it 'returns a JSON with the errors' do
+        # Used in admin/orders/edit
+        context 'when the request is JS/XHR (jquery-rails gem)' do
+          it "updates the line item" do
             xhr :put, :update, params
-            expect(JSON.parse(response.body)['errors']).to eq(errors)
+            line_item1.reload
+            expect(line_item1.quantity).to eq 3
+            expect(line_item1.final_weight_volume).to eq 3000
+            expect(line_item1.price).to eq 3.00
           end
 
-          it 'returns a 412 response' do
+          it "returns an empty JSON response" do
             xhr :put, :update, params
-            expect(response.status).to eq 412
+            expect(response.body).to eq ' '
+          end
+
+          it 'returns a 204 response' do
+            xhr :put, :update, params
+            expect(response.status).to eq 204
+          end
+
+          context 'when the line item params are not correct' do
+            let(:line_item_params) { { price: 'hola' } }
+            let(:errors) { { 'price' => ['is not a number'] } }
+
+            it 'returns a JSON with the errors' do
+              xhr :put, :update, params
+              expect(JSON.parse(response.body)['errors']).to eq(errors)
+            end
+
+            it 'returns a 412 response' do
+              xhr :put, :update, params
+              expect(response.status).to eq 412
+            end
+          end
+        end
+
+        # Used in admin/orders/bulk_management
+        context 'when the request is JSON (angular)' do
+          before { params[:format] = :json }
+
+          it "updates the line item" do
+            spree_put :update, params
+            line_item1.reload
+            expect(line_item1.quantity).to eq 3
+            expect(line_item1.final_weight_volume).to eq 3000
+            expect(line_item1.price).to eq 3.00
+          end
+
+          it "returns an empty JSON response" do
+            spree_put :update, params
+            expect(response.body).to eq ' '
+          end
+
+          it 'returns a 204 response' do
+            spree_put :update, params
+            expect(response.status).to eq 204
+          end
+
+          context 'when the line item params are not correct' do
+            let(:line_item_params) { { price: 'hola' } }
+            let(:errors) { { 'price' => ['is not a number'] } }
+
+            it 'returns a JSON with the errors' do
+              spree_put :update, params
+              expect(JSON.parse(response.body)['errors']).to eq(errors)
+            end
+
+            it 'returns a 412 response' do
+              spree_put :update, params
+              expect(response.status).to eq 412
+            end
           end
         end
 
         context 'when the request is HTML' do
-          before { params.merge(format: :html) }
+          before { params[:format] = :html }
 
           it 'returns an HTML response with the order form' do
             spree_put :update, params
@@ -246,20 +287,44 @@ describe Spree::Admin::LineItemsController do
       controller.stub spree_current_user: coordinator.owner
     end
 
-    it 'destroys the line item' do
-      expect {
+    # Used in admin/orders/edit
+    context 'when the request is JS/XHR (jquery-rails gem)' do
+      it 'destroys the line item' do
+        expect {
+          xhr :delete, :destroy, params
+        }.to change { Spree::LineItem.where(id: line_item1).count }.from(1).to(0)
+      end
+
+      it 'returns an empty JSON response' do
         xhr :delete, :destroy, params
-      }.to change { Spree::LineItem.where(id: line_item1).count }.from(1).to(0)
+        expect(response.body).to eq ' '
+      end
+
+      it 'returns a 204 response' do
+        xhr :delete, :destroy, params
+        expect(response.status).to eq 204
+      end
     end
 
-    it 'returns an empty JSON response' do
-      xhr :delete, :destroy, params
-      expect(response.body).to eq ' '
-    end
+    # Used in admin/orders/bulk_management
+    context 'when the request is JSON (angular)' do
+      before { params[:format] = :json }
 
-    it 'returns a 204 response' do
-      xhr :delete, :destroy, params
-      expect(response.status).to eq 204
+      it 'destroys the line item' do
+        expect {
+          spree_delete :destroy, params
+        }.to change { Spree::LineItem.where(id: line_item1).count }.from(1).to(0)
+      end
+
+      it 'returns an empty JSON response' do
+        spree_delete :destroy, params
+        expect(response.body).to eq ' '
+      end
+
+      it 'returns a 204 response' do
+        spree_delete :destroy, params
+        expect(response.status).to eq 204
+      end
     end
 
     context 'when the request is HTML' do


### PR DESCRIPTION
#### What? Why?

In the step 6 of the spree upgrade, when deleting an order's line item from `/admin` we get an HTML response (the whole edit form) that gets inserted into the flash error.

![](https://community.openfoodnetwork.org/uploads/default/original/1X/191ff149bfd9b0f728461c13220d312f0ef53dd1.png)

It's not 100% clear to me why we added a respond_to block for JSON but since jquery-rails sends ajax requests with `application/javascript, */*` in the ACCEPTS request header, Rails falls back to the first specified respond_to block, which is HTML. We don't hit the JSON block.

In order for this to work, this commit replaces the JSON respond_to block with one for JS with the exact same behaviour; returning a 204. This is also the format the spree controller action we duplicated originally has besides HTML. Check [core/app/controllers/spree/admin/line_items_controller.rb:9](https://github.com/openfoodfoundation/spree/blob/spree-upgrade-step1c/core/app/controllers/spree/admin/line_items_controller.rb#L9)

#### What should we test?

Deleting a line item while editing an order in `/admin` should simply remove it from the UI without any error.

#### How is this related to the Spree upgrade?

This is one of the multiple issues found in the testing of the step 6. See: [Spree testing june 2017](https://community.openfoodnetwork.org/t/spree-testing-june-2017/976)