### PR TITLE
Complete seed data to purchase to Enterprise 2

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -168,6 +168,91 @@ namespace :openfoodnetwork do
                                    :enterprise_fee => Enterprise.is_distributor[2].enterprise_fees.first)
 
       end
+
+      enterprise2 = Enterprise.find_by_name('Enterprise 2')
+      enterprise2.sells = 'any'
+      enterprise2.shipping_methods.build(
+        name: 'Pickup',
+        zone_id: 3,
+        require_ship_address: true,
+        calculator_type: 'OpenFoodNetwork::Calculator::Weight',
+        distributor_ids: [enterprise2.id]
+      )
+      enterprise2.payment_methods << Spree::PaymentMethod.last
+      enterprise2.save!
+
+      variants = Spree::Variant
+        .joins(:product)
+        .where('spree_products.supplier_id = ?', enterprise2.id)
+
+      CreateOrderCycle.new(enterprise2, variants).call
+    end
+
+    # Creates an order cycle for the provided enterprise and selecting all the
+    # variants specified for both incoming and outgoing exchanges
+    class CreateOrderCycle
+
+      # Constructor
+      #
+      # @param enterprise [Enterprise]
+      # @param variants [Array<Spree::Variant>]
+      def initialize(enterprise, variants)
+        @enterprise = enterprise
+        @variants = variants
+      end
+
+      # Creates the order cycle
+      def call
+        incoming_exchange.order_cycle = order_cycle
+        incoming_exchange.variants << variants
+
+        outgoing_exchange.order_cycle = order_cycle
+        outgoing_exchange.variants << variants
+
+        order_cycle.exchanges << incoming_exchange
+        order_cycle.exchanges << outgoing_exchange
+
+        order_cycle.save!
+      end
+
+      private
+
+      attr_reader :enterprise, :variants
+
+      # Builds an order cycle for the next month, starting now
+      #
+      # @return [OrderCycle]
+      def order_cycle
+        @order_cycle ||= OrderCycle.new(
+          coordinator_id: enterprise.id,
+          name: 'Monthly order cycle',
+          orders_open_at: Time.zone.now,
+          orders_close_at: Time.zone.now + 1.month
+        )
+      end
+
+      # Builds an exchange with the enterprise both as sender and receiver
+      #
+      # @return [Exchange]
+      def incoming_exchange
+        @incoming_exchange ||= Exchange.new(
+          sender_id: enterprise.id,
+          receiver_id: enterprise.id,
+          incoming: true
+        )
+      end
+
+      # Builds an exchange with the enterprise both as sender and receiver
+      #
+      # @return [Exchange]
+      def outgoing_exchange
+        @outgoing_exchange ||= Exchange.new(
+          sender_id: enterprise.id,
+          receiver_id: enterprise.id,
+          pickup_time: '8 am',
+          incoming: false
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
#### What? Why?

As I move between branches I have to reset my database often either because a column is missing or because I messed up the data. 

As it is, the seed data we have doesn't allow you to place an order right away thus, the time I spend every week setting everything up to test an order is considerable. So what I propose is just doing programatically what I do manually now.