### PR TITLE
Create a mail method when inserting seed data

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -9,6 +9,13 @@ namespace :openfoodnetwork do
       require_relative '../../spec/support/spree/init'
       task_name = "openfoodnetwork:dev:load_sample_data"
 
+      # -- MailMethod
+      # TODO: Remove me when in Spree 2.0. See http://guides.spreecommerce.org/release_notes/spree_2_0_0.html#mailmethod-model-no-longer-exists
+      Spree::MailMethod.create!(
+        environment: Rails.env,
+        preferred_mails_from: 'spree@example.com'
+      )
+
       # -- Shipping / payment information
       unless Spree::Zone.find_by_name 'Australia'
         puts "[#{task_name}] Seeding shipping / payment information"


### PR DESCRIPTION
#### What? Why?

This solves the [issue reported while testing the step 6 of the Spree upgrade](https://github.com/openfoodfoundation/openfoodnetwork/issues/1715) regarding mail method.

If there is no `Spree::MailMethod` no email can be sent. After creating it I can cancel an order again. When I click cancel from the `Actions` dropdown I receive the following email:

![screencapture-file-home-pau-dev-openfoodnetwork-tmp-letter_opener-1501163373_328a17a-plain-html-1501163395809](https://user-images.githubusercontent.com/762088/28674080-a69c022a-72e4-11e7-8cd2-dcd1652e0e93.png)

and the order shows as cancelled:

![screencapture-localhost-3000-admin-orders-r208144661-1501163416408](https://user-images.githubusercontent.com/762088/28674092-afb00f78-72e4-11e7-8e1c-1669d929eeca.png)

#### What should we test?

It should be possible to cancel an order as shown above