### PR TITLE
Revert "Load order also on open and close adjustments"

### DIFF
--- a/app/controllers/spree/admin/orders_controller_decorator.rb
+++ b/app/controllers/spree/admin/orders_controller_decorator.rb
@@ -4,7 +4,7 @@ Spree::Admin::OrdersController.class_eval do
   include OpenFoodNetwork::SpreeApiKeyLoader
   helper CheckoutHelper
   before_filter :load_spree_api_key, :only => :bulk_management
-  before_filter :load_order, only: %i[show edit update fire resend invoice print open_adjustments close_adjustments]
+  before_filter :load_order, only: %i[show edit update fire resend invoice print]
 
   before_filter :load_distribution_choices, only: [:new, :edit, :update]
 

--- a/spec/features/admin/variant_overrides_spec.rb
+++ b/spec/features/admin/variant_overrides_spec.rb
@@ -320,24 +320,24 @@ feature %q{
 
     describe "when manually placing an order" do
       let!(:order_cycle) { create(:order_cycle_with_overrides, name: "Overidden") }
+      let(:distributor) { order_cycle.distributors.first }
+      let(:product) { order_cycle.products.first }
 
       before do
-        dist = order_cycle.distributors.first
         login_to_admin_section
+
         visit 'admin/orders/new'
-        select2_select dist.name, from: 'order_distributor_id'
-        page.should have_select2 'order_order_cycle_id', with_options: ['Overidden (open)']
+        select2_select distributor.name, from: 'order_distributor_id'
         select2_select order_cycle.name, from: 'order_order_cycle_id'
         click_button 'Next'
       end
 
       # Reproducing a bug, issue #1446
       it "shows the overridden price" do
-        product = order_cycle.products.first
         targetted_select2_search product.name, from: '#add_variant_id', dropdown_css: '.select2-drop'
         click_link 'Add'
-        page.has_selector? "table.index tbody[data-hook='admin_order_form_line_items'] tr"  # Wait for JS
-        page.should have_content product.variants.first.variant_overrides.first.price
+        expect(page).to have_selector("table.index tbody[data-hook='admin_order_form_line_items'] tr") # Wait for JS
+        expect(page).to have_content(product.variants.first.variant_overrides.first.price)
       end
     end
 


### PR DESCRIPTION
This reverts commit d77588431aa26422e2956fd3510a20b35dab1b1c.

#### What? Why?

As discussed in https://github.com/openfoodfoundation/openfoodnetwork/issues/1712 we need to wait until Spree 2.0 to see this feature fully implemented.

#### What should we test?

We should not see neither the `open all adjustments` nor the `close all adjustments` buttons in the checkout process. The column `state` should also be gone.