### PR TITLE
Refactor spec using `expect_any_instance`

### DIFF
--- a/spec/controllers/admin/bulk_line_items_controller_spec.rb
+++ b/spec/controllers/admin/bulk_line_items_controller_spec.rb
@@ -177,8 +177,11 @@ describe Admin::BulkLineItemsController do
           end
 
           it 'applies enterprise fees locking the order with an exclusive row lock' do
-            expect_any_instance_of(Spree::Order).to receive(:reload).with(lock: true)
-            expect_any_instance_of(Spree::Order).to receive(:update_distribution_charge!)
+            allow(Spree::LineItem)
+              .to receive(:find).with(line_item1.id.to_s).and_return(line_item1)
+
+            expect(line_item1.order).to receive(:reload).with(lock: true)
+            expect(line_item1.order).to receive(:update_distribution_charge!)
 
             spree_put :update, params
           end


### PR DESCRIPTION
#### What? Why?

In https://github.com/Em-AK/openfoodnetwork/pull/16/files#diff-a608492539c84613532313634418dd1dR181 I desperately introduced a rspec bad practice using `expect_any_instance_of`.

The issue was that I was setting an expectation on an `order` in the test but then the controller was loading the order from DB, thus instantiating a different object with its own obect_id. Obviously the object being stubbed and the one used by the controller were different.

I fixed it stubbing `find` and returning the appropriate object.

#### What should we test?

Nothing. This affects tests only.